### PR TITLE
修复三级菜单时expandAllParent()数据错位的问题，修复当数据较多时有时无法expand展开的问题

### DIFF
--- a/expandablerecycleradapter/src/main/java/com/zaihuishou/expandablerecycleradapter/adapter/BaseExpandableAdapter.java
+++ b/expandablerecycleradapter/src/main/java/com/zaihuishou/expandablerecycleradapter/adapter/BaseExpandableAdapter.java
@@ -298,7 +298,7 @@ public abstract class BaseExpandableAdapter extends RecyclerView.Adapter impleme
     }
 
     /**
-     * expand index item
+     * expand index item (Notice: only fixed to just adjust triple level, not available for higher level!!!!!!!)
      *
      * @param expandableListItem
      * @param parentIndex                       The index of the parent to collapse
@@ -313,6 +313,14 @@ public abstract class BaseExpandableAdapter extends RecyclerView.Adapter impleme
                 for (int i = 0; i < childListItemCount; i++) {
                     Object o = childItemList.get(i);
                     int newIndex = parentIndex + i + 1;
+                    if (isExpandAllChildren && i > 0) {
+                        for(int j = 0; j < i; j++){
+                            Object childBefore = childItemList.get(j);
+                            if(childBefore instanceof ExpandableListItem){
+                                newIndex += ((ExpandableListItem) childBefore).getChildItemList().size();
+                            }
+                        }
+                    }
                     mDataList.add(newIndex, o);
                     notifyItemInserted(newIndex);
                     if (isExpandAllChildren)


### PR DESCRIPTION
1、当有三级菜单时，expandAllParent()之后会出现数据错位，问题是二级Parent的子list没有算在index中；
2、当三级菜单较多、并且每一个菜单数据量较多时，完全展开第一级菜单的某一个子List之后再收起该菜单，然后点击其他的三级菜单时有可能会 出现无法展开的情况。问题是当完全展开之后，在最下面的三级菜单在没有执行onBindViewHolder()方法，所以它的index是之前的并没有改变，我这里为了让Recyclerview的Range动画显示就延迟了300ms进行notifyDataSetChanged，感觉有点粗暴，但是没有想到其他好的办法。